### PR TITLE
DTSPO-2879 - Adding depends_on in kubernetes module

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -69,6 +69,7 @@ module "kubernetes" {
       enable_auto_scaling = true
     }
   ]
+  depends_on = [azurerm_resource_group.disks_resource_group]
 }
 
 module "ctags" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2879

### Change description ###
Pipeline currently failing as data resource inside module is ran before resource group is created

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
