### PR TITLE
Only install Flux v1 for non-migrated envs

### DIFF
--- a/bootstrap/deploy-flux.sh
+++ b/bootstrap/deploy-flux.sh
@@ -180,7 +180,6 @@ sleep 60
 helm_add_repo
 echo "****  repo added ****"
 helm_apply_crd ${HELM_OPERATOR_VER}
-echo "****  ssh key added ****"
 flux_helm_operator_install
 echo "**** helm operator is now installed ****"
 
@@ -201,6 +200,7 @@ if [[ " ${FLUX_V2_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
     pod_identity_components
     pod_identity_flux_sop_setup
     flux_ssh_git_key
+    echo "****  ssh key added ****"
     flux_install ${flux_repo_list} ${ENVIRONMENT} v3
     echo "****  flux is now installed ****"
 fi

--- a/bootstrap/deploy-flux.sh
+++ b/bootstrap/deploy-flux.sh
@@ -175,17 +175,12 @@ EOF
 ############################################################
 
 flux_create_namespace
-pod_identity_components
-pod_identity_flux_sop_setup
 # give a bit of time for identity to sync so that flux start's correctly first time
 sleep 60
 helm_add_repo
 echo "****  repo added ****"
 helm_apply_crd ${HELM_OPERATOR_VER}
-flux_ssh_git_key
 echo "****  ssh key added ****"
-flux_install ${flux_repo_list} ${ENVIRONMENT} v3
-echo "****  flux is now installed ****"
 flux_helm_operator_install
 echo "**** helm operator is now installed ****"
 
@@ -198,4 +193,14 @@ if [[ " ${FLUX_V2_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
     flux_v2_pod_identity_sops_setup
     flux_v2_ssh_git_key
     flux_v2_installation
+fi
+
+FLUX_V1_CLUSTERS=( 'dev' 'demo' 'ithc' 'prod' 'ptlsbox' 'stg' 'test' )
+
+if [[ " ${FLUX_V2_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
+    pod_identity_components
+    pod_identity_flux_sop_setup
+    flux_ssh_git_key
+    flux_install ${flux_repo_list} ${ENVIRONMENT} v3
+    echo "****  flux is now installed ****"
 fi

--- a/bootstrap/deploy-flux.sh
+++ b/bootstrap/deploy-flux.sh
@@ -196,7 +196,7 @@ fi
 
 FLUX_V1_CLUSTERS=( 'dev' 'demo' 'ithc' 'prod' 'ptlsbox' 'stg' 'test' )
 
-if [[ " ${FLUX_V2_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
+if [[ " ${FLUX_V1_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
     pod_identity_components
     pod_identity_flux_sop_setup
     flux_ssh_git_key

--- a/bootstrap/deploy-flux.sh
+++ b/bootstrap/deploy-flux.sh
@@ -194,7 +194,7 @@ if [[ " ${FLUX_V2_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
     flux_v2_installation
 fi
 
-FLUX_V1_CLUSTERS=( 'dev' 'demo' 'ithc' 'prod' 'ptlsbox' 'stg' 'test' )
+FLUX_V1_CLUSTERS=( 'dev' 'demo' 'ithc' 'stg' 'test' 'prod' 'ptlsbox' 'ptl')
 
 if [[ " ${FLUX_V1_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
     pod_identity_components


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/DTSPO-5953


### Change description ###
Update bootstrap script to only install Flux v1 for non-migrated envs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
