### PR TITLE
Patch AKS version dev to 1.22.4

### DIFF
--- a/environments/aks/dev.tfvars
+++ b/environments/aks/dev.tfvars
@@ -1,5 +1,5 @@
 cluster_count              = 2
-kubernetes_cluster_version = "1.21.2"
+kubernetes_cluster_version = "1.22.4"
 kubernetes_cluster_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqPFmlkJn9vCOklB9wOJEAr+h36naEvWCH2LP6wVMTnbWkgwwhRvtVGeFeDo5jhlTJGk8/RyCnuQpoKfvfYNqr/5fhr0xa7CNJhb2NdUmv8u811APXKaf8psElQz4LzFb6HBcKapkVB1DQwUCVREY+BCnXtBZ1v6V24TO9YbJASs/BaPgZQJLThVGNe24jV0zRWDAy1RElPT8P1wO4k5hoDXg4NRoQt5IxqcpTUncVGN705ggqLf96zS70fPVlhLL5L6yBv4/0y9t4uo7NR5mKwDIRlpyXONpFpMGzj0zWLm/HDQqZNrD4Ycs2UolJcBk+YlUXTV6VyrnpmyKoVGvlOW8IpJLASW8HalNeOWTw5WsbjpY8rCrgasO6lMC3tI7t8yqFHFJ+EAqYZtVJoLO+ag97QZADlm2vcvctSGCAr8hqwYfb2UqqlDTuX/H8USqelCNa5NJAH7IMF1p1M9n0ohvT91U3KdtUvgu/8psuIXD1iEDNKQ3gwManbeRQ79M="
 availability_zones         = ["1"]
 


### PR DESCRIPTION
### Change description ###
To get around this:
`│ Error: creating Managed Kubernetes Cluster "ss-dev-01-aks" (Resource Group "ss-dev-01-rg"): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.21.2 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check [https://aka.ms/supported-version-list"](https://aka.ms/supported-version-list%22)`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
