### PR TITLE
move AKS additional IAMs to new component

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ stages:
               builtFrom: $(Build.Repository.Name)
               product: ${{ variables.product }}
               ${{ if ne(parameters['cluster'], 'All') }}:
-                targetCommand: "-target azurerm_resource_group.kubernetes_resource_group[${{parameters.cluster}}] -target module.kubernetes[${{parameters.cluster}}] -target azurerm_role_assignment.dev_to_stg[${{parameters.cluster}}] -target data.azurerm_resource_group.mi_stg_rg[${{parameters.cluster}}]"
+                targetCommand: "-target data.azurerm_kubernetes_cluster.kubernetes[${{parameters.cluster}}] -target module.kubernetes[${{parameters.cluster}}] -target azurerm_role_assignment.dev_to_stg[${{parameters.cluster}}] -target data.azurerm_resource_group.mi_stg_rg[${{parameters.cluster}}]"
 
   - stage: BootStrapClusters
     displayName: 'BootStrap Clusters'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ stages:
               builtFrom: $(Build.Repository.Name)
               product: ${{ variables.product }}
               ${{ if ne(parameters['cluster'], 'All') }}:
-                targetCommand: "-target azurerm_role_assignment.dev_to_stg[${{parameters.cluster}}] -target data.azurerm_resource_group.mi_stg_rg[${{parameters.cluster}}]"
+                targetCommand: "-target azurerm_resource_group.kubernetes_resource_group[${{parameters.cluster}}] -target module.kubernetes[${{parameters.cluster}}] -target azurerm_role_assignment.dev_to_stg[${{parameters.cluster}}] -target data.azurerm_resource_group.mi_stg_rg[${{parameters.cluster}}]"
 
   - stage: BootStrapClusters
     displayName: 'BootStrap Clusters'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,22 @@ stages:
               builtFrom: $(Build.Repository.Name)
               product: ${{ variables.product }}
               ${{ if ne(parameters['cluster'], 'All') }}:
-                targetCommand: "-target azurerm_resource_group.kubernetes_resource_group[${{parameters.cluster}}] -target module.kubernetes[${{parameters.cluster}}] -target azurerm_role_assignment.dev_to_stg[${{parameters.cluster}}] -target data.azurerm_resource_group.mi_stg_rg[${{parameters.cluster}}]"
+                targetCommand: "-target azurerm_resource_group.kubernetes_resource_group[${{parameters.cluster}}] -target module.kubernetes[${{parameters.cluster}}]"
+      - job: DeployInfrastructureaksiam
+        dependsOn: DeployInfrastructure
+        steps:
+          - template: pipeline-steps/deploy-service.yaml
+            parameters:
+              environment: ${{ parameters.env }}
+              location: ${{ parameters.location }}
+              stack: 'aks-iam'
+              project: $(project)
+              tfversion: $(tfversion)
+              tfInitSub: ${{ variables.tfInitSub }}
+              builtFrom: $(Build.Repository.Name)
+              product: ${{ variables.product }}
+              ${{ if ne(parameters['cluster'], 'All') }}:
+                targetCommand: "-target azurerm_role_assignment.dev_to_stg[${{parameters.cluster}}] -target data.azurerm_resource_group.mi_stg_rg[${{parameters.cluster}}]"
 
   - stage: BootStrapClusters
     displayName: 'BootStrap Clusters'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
               builtFrom: $(Build.Repository.Name)
               product: ${{ variables.product }}
               ${{ if ne(parameters['cluster'], 'All') }}:
-                targetCommand: "-target azurerm_resource_group.kubernetes_resource_group[${{parameters.cluster}}] -target module.kubernetes[${{parameters.cluster}}]"
+                targetCommand: "-target azurerm_resource_group.kubernetes_resource_group[${{parameters.cluster}}] -target module.kubernetes[${{parameters.cluster}}] -target azurerm_role_assignment.dev_to_stg[${{parameters.cluster}}] -target data.azurerm_resource_group.mi_stg_rg[${{parameters.cluster}}]"
       - job: DeployInfrastructureaksiam
         dependsOn: DeployInfrastructure
         steps:

--- a/components/aks-iam/aks-mis.tf
+++ b/components/aks-iam/aks-mis.tf
@@ -10,7 +10,7 @@ resource "azurerm_role_assignment" "dev_to_stg" {
   provider             = azurerm.dts-ss-stg
   role_definition_name = "Managed Identity Operator"
   principal_id         = data.azurerm_kubernetes_cluster.kubernetes["${count.index}"].kubelet_identity[0].object_id
-  scope                = data.azurerm_resource_group.mi_stg_rg.id
+  scope                = data.azurerm_resource_group.mi_stg_rg[0].id
 }
 
 data "azurerm_kubernetes_cluster" "kubernetes" {

--- a/components/aks-iam/aks-mis.tf
+++ b/components/aks-iam/aks-mis.tf
@@ -1,0 +1,20 @@
+data "azurerm_resource_group" "mi_stg_rg" {
+  provider = azurerm.dts-ss-stg
+  name     = "managed-identities-stg-rg"
+
+  count    = local.is_dev ? 1 : 0
+}
+
+resource "azurerm_role_assignment" "dev_to_stg" {
+  count                = local.is_dev ? var.cluster_count : 0
+  provider             = azurerm.dts-ss-stg
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = data.azurerm_kubernetes_cluster.kubernetes["${count.index}"].kubelet_identity[0].object_id
+  scope                = data.azurerm_resource_group.mi_stg_rg[0].id
+}
+
+data "azurerm_kubernetes_cluster" "kubernetes" {
+  count               = var.cluster_count
+  name                = "${var.project}-${var.environment}-0${count.index}-${var.service_shortname}"
+  resource_group_name = "${var.project}-${var.environment}-0${count.index}-rg"
+}

--- a/components/aks-iam/aks-mis.tf
+++ b/components/aks-iam/aks-mis.tf
@@ -10,7 +10,7 @@ resource "azurerm_role_assignment" "dev_to_stg" {
   provider             = azurerm.dts-ss-stg
   role_definition_name = "Managed Identity Operator"
   principal_id         = data.azurerm_kubernetes_cluster.kubernetes["${count.index}"].kubelet_identity[0].object_id
-  scope                = data.azurerm_resource_group.mi_stg_rg[0].id
+  scope                = data.azurerm_resource_group.mi_stg_rg.id
 }
 
 data "azurerm_kubernetes_cluster" "kubernetes" {

--- a/components/aks-iam/aks-mis.tf
+++ b/components/aks-iam/aks-mis.tf
@@ -2,7 +2,7 @@ data "azurerm_resource_group" "mi_stg_rg" {
   provider = azurerm.dts-ss-stg
   name     = "managed-identities-stg-rg"
 
-  count    = local.is_dev ? 1 : 0
+  # count    = local.is_dev ? 1 : 0
 }
 
 resource "azurerm_role_assignment" "dev_to_stg" {

--- a/components/aks-iam/aks-mis.tf
+++ b/components/aks-iam/aks-mis.tf
@@ -11,6 +11,7 @@ resource "azurerm_role_assignment" "dev_to_stg" {
   role_definition_name = "Managed Identity Operator"
   principal_id         = data.azurerm_kubernetes_cluster.kubernetes["${count.index}"].kubelet_identity[0].object_id
   scope                = data.azurerm_resource_group.mi_stg_rg[0].id
+  depends_on         = [data.azurerm_resource_group.mi_stg_rg]
 }
 
 data "azurerm_kubernetes_cluster" "kubernetes" {

--- a/components/aks-iam/aks-mis.tf
+++ b/components/aks-iam/aks-mis.tf
@@ -11,7 +11,6 @@ resource "azurerm_role_assignment" "dev_to_stg" {
   role_definition_name = "Managed Identity Operator"
   principal_id         = data.azurerm_kubernetes_cluster.kubernetes["${count.index}"].kubelet_identity[0].object_id
   scope                = data.azurerm_resource_group.mi_stg_rg[0].id
-  depends_on         = [data.azurerm_resource_group.mi_stg_rg]
 }
 
 data "azurerm_kubernetes_cluster" "kubernetes" {

--- a/components/aks-iam/init.tf
+++ b/components/aks-iam/init.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.0.7"
+
+  backend "azurerm" {
+    subscription_id = "04d27a32-7a07-48bf3-95b8-3c8691e1a263"
+  }
+  required_providers {
+    azurerm = {
+      source                = "hashicorp/azurerm"
+      version               = "2.77.0"
+      configuration_aliases = [azurerm.hmcts-control]
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  is_dev  = var.environment == "dev" || var.environment == "test" || var.environment == "demo"  ? true : false
+}
+
+provider "azurerm" {
+  alias                      = "dts-ss-stg"
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
+}

--- a/components/aks-iam/inputs-required.tf
+++ b/components/aks-iam/inputs-required.tf
@@ -1,0 +1,14 @@
+# General
+variable "environment" {}
+
+variable "project" {}
+
+variable "product" {}
+
+variable "cluster_count" {}
+# Remote State
+variable "control_vault" {}
+
+variable "service_shortname" {
+  default = "aks"
+}

--- a/components/aks-iam/inputs-required.tf
+++ b/components/aks-iam/inputs-required.tf
@@ -9,6 +9,12 @@ variable "cluster_count" {}
 # Remote State
 variable "control_vault" {}
 
+variable "builtFrom" {}
+
+variable "location" {
+  default = "uksouth"
+}
+
 variable "service_shortname" {
   default = "aks"
 }

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -120,19 +120,3 @@ resource "azurerm_role_assignment" "sbox_registry_acrpull" {
   principal_id         = module.kubernetes[count.index].kubelet_object_id
   scope                = data.azurerm_resource_group.sds_sbox_acr[0].id
 }
-
-
-# data "azurerm_resource_group" "mi_stg_rg" {
-#   provider = azurerm.dts-ss-stg
-#   name     = "managed-identities-stg-rg"
-
-#   count    = local.is_dev ? 1 : 0
-# }
-
-# resource "azurerm_role_assignment" "dev_to_stg" {
-#   count                = local.is_dev ? var.cluster_count : 0
-#   provider             = azurerm.dts-ss-stg
-#   role_definition_name = "Managed Identity Operator"
-#   principal_id         = module.kubernetes[count.index].kubelet_object_id
-#   scope                = data.azurerm_resource_group.mi_stg_rg[0].id
-# }

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -122,17 +122,17 @@ resource "azurerm_role_assignment" "sbox_registry_acrpull" {
 }
 
 
-data "azurerm_resource_group" "mi_stg_rg" {
-  provider = azurerm.dts-ss-stg
-  name     = "managed-identities-stg-rg"
+# data "azurerm_resource_group" "mi_stg_rg" {
+#   provider = azurerm.dts-ss-stg
+#   name     = "managed-identities-stg-rg"
 
-  count    = local.is_dev ? 1 : 0
-}
+#   count    = local.is_dev ? 1 : 0
+# }
 
-resource "azurerm_role_assignment" "dev_to_stg" {
-  count                = local.is_dev ? var.cluster_count : 0
-  provider             = azurerm.dts-ss-stg
-  role_definition_name = "Managed Identity Operator"
-  principal_id         = module.kubernetes[count.index].kubelet_object_id
-  scope                = data.azurerm_resource_group.mi_stg_rg[0].id
-}
+# resource "azurerm_role_assignment" "dev_to_stg" {
+#   count                = local.is_dev ? var.cluster_count : 0
+#   provider             = azurerm.dts-ss-stg
+#   role_definition_name = "Managed Identity Operator"
+#   principal_id         = module.kubernetes[count.index].kubelet_object_id
+#   scope                = data.azurerm_resource_group.mi_stg_rg[0].id
+# }

--- a/environments/aks-iam/demo.tfvars
+++ b/environments/aks-iam/demo.tfvars
@@ -1,0 +1,1 @@
+cluster_count                      = 2

--- a/environments/aks-iam/dev.tfvars
+++ b/environments/aks-iam/dev.tfvars
@@ -1,0 +1,1 @@
+cluster_count              = 2

--- a/environments/aks-iam/ithc.tfvars
+++ b/environments/aks-iam/ithc.tfvars
@@ -1,0 +1,1 @@
+cluster_count              = 2

--- a/environments/aks-iam/prod.tfvars
+++ b/environments/aks-iam/prod.tfvars
@@ -1,0 +1,1 @@
+cluster_count                      = 2

--- a/environments/aks-iam/ptl.tfvars
+++ b/environments/aks-iam/ptl.tfvars
@@ -1,0 +1,1 @@
+cluster_count                      = 1

--- a/environments/aks-iam/ptlsbox.tfvars
+++ b/environments/aks-iam/ptlsbox.tfvars
@@ -1,0 +1,1 @@
+cluster_count                      = 1

--- a/environments/aks-iam/sbox.tfvars
+++ b/environments/aks-iam/sbox.tfvars
@@ -1,0 +1,1 @@
+cluster_count              = 2

--- a/environments/aks-iam/stg.tfvars
+++ b/environments/aks-iam/stg.tfvars
@@ -1,0 +1,1 @@
+cluster_count              = 2

--- a/environments/aks-iam/test.tfvars
+++ b/environments/aks-iam/test.tfvars
@@ -1,0 +1,1 @@
+cluster_count              = 2


### PR DESCRIPTION
### Change description ###
- moved custom IAM permissions to a new component 
- terraform destroy doesn't nuke the custom IAM permissions during  a destroy now of module (because count is used it cannot determine to use [1] etc during destroy
- no additional destroy needed; tested in CFT & during redeploy it will recreate/deploy the IAM permissions correctly, during next terraform apply of a destroyed AKS cluster

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
