### PR TITLE
DTSPO-6917 Upgrade Kubernetes version to 1.22.4 and enable Flux v2 for Staging clusters

### DIFF
--- a/bootstrap/deploy-flux.sh
+++ b/bootstrap/deploy-flux.sh
@@ -185,7 +185,7 @@ EOF
 # End of functions
 ############################################################
 
-FLUX_V2_CLUSTERS=( 'ptl' 'sbox' 'dev' )
+FLUX_V2_CLUSTERS=( 'ptl' 'sbox' 'dev' 'stg' )
 
 if [[ " ${FLUX_V2_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
     TMP_DIR=/tmp/flux/${ENVIRONMENT}/${CLUSTER_NAME}

--- a/environments/aks/stg.tfvars
+++ b/environments/aks/stg.tfvars
@@ -1,5 +1,5 @@
 cluster_count              = 2
-kubernetes_cluster_version = "1.21.2"
+kubernetes_cluster_version = "1.22.4"
 
 kubernetes_cluster_agent_min_count = "2"
 kubernetes_cluster_agent_max_count = "4"


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/DTSPO-6917


### Change description ###
Upgrade Kubernetes version to 1.22.4 and enable Flux v2 for Staging clusters


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
