### PR TITLE
DTSPO-6371 - fix private endpoint subnets

### DIFF
--- a/environments/01-network/demo.tfvars
+++ b/environments/01-network/demo.tfvars
@@ -21,7 +21,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.51.98.128/22"
+    address_prefix = "10.51.99.0/22"
   },
 ]
 

--- a/environments/01-network/dev.tfvars
+++ b/environments/01-network/dev.tfvars
@@ -21,7 +21,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.145.34.128/22"
+    address_prefix = "10.145.35.0/22"
   },
 ]
 

--- a/environments/01-network/ithc.tfvars
+++ b/environments/01-network/ithc.tfvars
@@ -21,7 +21,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.143.34.128/22"
+    address_prefix = "10.143.35.0/22"
   },
 ]
 

--- a/environments/01-network/prod.tfvars
+++ b/environments/01-network/prod.tfvars
@@ -21,7 +21,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.144.34.128/22"
+    address_prefix = "10.144.35.0/22"
   },
 ]
 

--- a/environments/01-network/sbox.tfvars
+++ b/environments/01-network/sbox.tfvars
@@ -21,7 +21,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.140.34.128/22"
+    address_prefix = "10.140.35.0/22"
   },
 ]
 

--- a/environments/01-network/stg.tfvars
+++ b/environments/01-network/stg.tfvars
@@ -21,7 +21,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.148.34.128/22"
+    address_prefix = "10.148.35.0/22"
   },
 ]
 

--- a/environments/01-network/test.tfvars
+++ b/environments/01-network/test.tfvars
@@ -21,7 +21,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.141.34.128/22"
+    address_prefix = "10.141.35.0/22"
   },
 ]
 


### PR DESCRIPTION
### Change description ###
Fixing the private endpoint subnets, /22 needs to start on x.x.x.0, otherwise it is incorrect.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
