### PR TITLE
DTSPO-6489 - enable fluxv2 on ithc

### DIFF
--- a/bootstrap/deploy-flux.sh
+++ b/bootstrap/deploy-flux.sh
@@ -185,7 +185,7 @@ EOF
 # End of functions
 ############################################################
 
-FLUX_V2_CLUSTERS=( 'ptl' 'sbox' 'dev' 'stg' 'prod' )
+FLUX_V2_CLUSTERS=( 'ptl' 'sbox' 'dev' 'stg' 'prod' 'ithc' )
 
 if [[ " ${FLUX_V2_CLUSTERS[*]} " =~ " ${ENVIRONMENT} " ]]; then
     TMP_DIR=/tmp/flux/${ENVIRONMENT}/${CLUSTER_NAME}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6489


### Change description ###
Enable flux v2 on ithc environment via deploy-flux.sh


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
