### PR TITLE
Increase max node size for scaling

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -26,7 +26,7 @@ locals {
     name                = "linux"
     vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")
     min_count           = lookup(var.linux_node_pool, "min_nodes", 2)
-    max_count           = lookup(var.linux_node_pool, "max_nodes", 4)
+    max_count           = lookup(var.linux_node_pool, "max_nodes", 10)
     max_pods            = lookup(var.linux_node_pool, "max_pods", 30)
     os_type             = "Linux"
     node_taints         = []


### PR DESCRIPTION
Juror Digital NLE down a few times in ss-dev from 
```
pod didn't trigger scale-up: 1 node(s) had taint {CriticalAddonsOnly: true}, that the pod didn't tolerate, 1 node(s) had taint {kubernetes.io/os: windows}, that the pod didn't tolerate, 1 max node group size reached
```

Resolved this by deleting other failed pods, had a chat with Ben and suggested we raise the maximum anyway, I think this is the right value to update?


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
