### PR TITLE
DTSPO-9517 - Remove ithc-01 cluster

### DIFF
--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -1,10 +1,10 @@
 clusters = {
   "00" = {
     kubernetes_version = "1.22.6"
-  },
-  "01" = {
-    kubernetes_version = "1.22.6"
   }
+  # "01" = {
+  #   kubernetes_version = "1.22.6"
+  # }
 }
 kubernetes_cluster_agent_min_count = "1"
 kubernetes_cluster_agent_max_count = "4"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-9517


### Change description ###
Remove ithc-01 cluster
Will be re-added in subsequent PR
Testing that managed identity is being used to authenticate to azure container registry


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
