### PR TITLE
DTSPO-9539 - set csi driver add-on to be deployed

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -57,7 +57,7 @@ module "kubernetes" {
 
   kubelet_uami_enabled = true
   oms_agent_enabled    = var.oms_agent_enabled
-  csi_driver_enabled   = tobool(lookup(var.clusters[each.value], "csi_driver_enabled", false))
+  csi_driver_enabled   = tobool(lookup(var.clusters[each.value], "csi_driver_enabled", true))
 
   providers = {
     azurerm               = azurerm

--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -1,9 +1,11 @@
 clusters = {
   "00" = {
     kubernetes_version = "1.22.6"
+    csi_driver_enabled = false
   },
   "01" = {
     kubernetes_version = "1.22.6"
+    csi_driver_enabled = false
   }
 }
 kubernetes_cluster_agent_min_count = "4"

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -3,8 +3,7 @@ clusters = {
     kubernetes_version = "1.22.6"
   },
   "01" = {
-    kubernetes_version  = "1.22.6"
-    csi_driver_enabled  = true
+    kubernetes_version = "1.22.6"
   }
 }
 


### PR DESCRIPTION
### Change description ###
- Set csi driver add-on to be deployed by default 
- Don't enable in prod
- Clean up sbox

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
