### PR TITLE
Revert updatecli config to single template

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -31,13 +31,24 @@ jobs:
         with:
           version: v0.33.3
 
+      - name: Install YQ
+        uses: mikefarah/yq@master
+
       - name: Run Updatecli in Dry Run mode
-        run: updatecli diff --config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml
+        run: |
+          yq '.environments' updatecli/values.github-action.yaml | cut -d "-" -f 2 | while read i
+          do
+              CURRENT_ITER_ENVIRONMENT="$i" updatecli diff --config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml
+          done
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Updatecli in Apply mode
         if: github.ref == 'refs/heads/master'
-        run: updatecli apply --config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml
+        run: |
+          yq '.environments' updatecli/values.github-action.yaml | cut -d "-" -f 2 | while read i
+          do
+              CURRENT_ITER_ENVIRONMENT="$i" updatecli apply --config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml
+          done
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/weekly.d/aks-version.yaml
+++ b/updatecli/weekly.d/aks-version.yaml
@@ -27,30 +27,27 @@ sources:
           pattern: ((\d+\.)?(\d+))?(\*|\.\d+)
           captureindex: 1
 
+{{ $environment := (requiredEnv "CURRENT_ITER_ENVIRONMENT") }}
+
 targets:
-  {{- range .environments }}
-  {{ . }}:
+  default:
     sourceid: latestAksVersion
     name: Bump major AKS version
     kind: file
     scmid: default
     spec:
-      file: "environments/aks/{{ .  }}.tfvars"
+      file: "environments/aks/{{ $environment }}.tfvars"
       matchpattern: 'kubernetes_version = \"(\d+\.)?(\d+\.)?(\*|\d+)\"'
       content: 'kubernetes_version  = "{{ source `latestAksVersion` }}"'
-  {{- end }}
 
 pullrequests:
-  {{- range .environments }}
-  {{ . }}:
+  default:
     kind: github
     scmid: default
-    targets: ["{{ . }}"]
     title: >-
-      [updatecli] [{{ . }}] Bump AKS version to {{ source "latestAksVersion" }}
+      [updatecli] [{{ $environment }}] Bump AKS version to {{ source "latestAksVersion" }}
     spec:
       automerge: false
       draft: false
       description: |
         Bump major aks version to {{ source "latestAksVersion" }}
-  {{- end }}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-10771

### Change description ###

Revert updatecli to use single configuration template and loop over environments instead.
Issue raised on updatecli github to address the issues with targets/pull requests.
Tracked originally under [DTSPO-10747](https://tools.hmcts.net/jira/browse/DTSPO-10747) 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
