### PR TITLE
DTSPO-10551 - Upgrade SBOX Cluster to 1.23

### DIFF
--- a/components/00-genesis/00-init.tf
+++ b/components/00-genesis/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.24.0"
+      version = "3.27.0"
     }
   }
 }

--- a/components/01-network/00-init.tf
+++ b/components/01-network/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.24.0"
+      version = "3.27.0"
     }
   }
 }

--- a/components/05-mis/00-init.tf
+++ b/components/05-mis/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.24.0"
+      version = "3.27.0"
     }
   }
 }

--- a/components/07-network-rg/00-init.tf
+++ b/components/07-network-rg/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.24.0"
+      version = "3.27.0"
     }
   }
 }

--- a/components/aks/init.tf
+++ b/components/aks/init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "3.24.0"
+      version               = "3.27.0"
       configuration_aliases = [azurerm.hmcts-control]
     }
   }

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -1,9 +1,9 @@
 clusters = {
   "00" = {
-    kubernetes_version = "1.24"
+    kubernetes_version = "1.23"
   },
   "01" = {
-    kubernetes_version = "1.24"
+    kubernetes_version = "1.23"
   }
 }
 

--- a/modules/vnet_peering/init.tf
+++ b/modules/vnet_peering/init.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "3.24.0"
+      version               = "3.27.0"
       configuration_aliases = [azurerm.initiator, azurerm.target]
     }
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-10551


### Change description ###
Upgrade SBOX Cluster to 1.23
(Code changed from 1.24 -> 1.23 as can only bump one version at a time. Clusters currently on version 1.22)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
