### PR TITLE
Return current kubernetes version when no non-preview upgrades available

### DIFF
--- a/updatecli/get-latest-aks-upgrade-version.sh
+++ b/updatecli/get-latest-aks-upgrade-version.sh
@@ -9,7 +9,7 @@ az aks get-upgrades \
     --resource-group $aks_resource_group \
     --subscription $aks_subscription \
     | jq -r '
-    if (.controlPlaneProfile.upgrades == null) then
+    if (.controlPlaneProfile.upgrades|map(select(.isPreview == null)) == []) then
         .controlPlaneProfile.kubernetesVersion
     else .controlPlaneProfile.upgrades|map(select(.isPreview == null).kubernetesVersion)
     | .[] end' \


### PR DESCRIPTION
### Change description ###
This fixes `ERROR: ✗ validation error: transformer input is empty` breaking the pipeline, when there's only preview upgrades available.

Example of:
```json
{
  "agentPoolProfiles": null,
  "controlPlaneProfile": {
    "kubernetesVersion": "1.24.6",
    "name": null,
    "osType": "Linux",
    "upgrades": [
      {
        "isPreview": true,
        "kubernetesVersion": "1.25.2"
      }
    ]
  },
  "id": "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourcegroups/ss-sbox-00-rg/providers/Microsoft.ContainerService/managedClusters/ss-sbox-00-aks/upgradeprofiles/default",
  "name": "default",
  "resourceGroup": "ss-sbox-00-rg",
  "type": "Microsoft.ContainerService/managedClusters/upgradeprofiles"
}
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
