### PR TITLE
Move AKS clusters stage to hmcts-cftptl-agent-pool self hosted pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,12 +172,12 @@ stages:
               planCommandOptions: "-var project=$(project) -var control_vault=$(controlKeyVault) -var subscription_id=$(ARM_SUBSCRIPTION_ID) "
          
   - stage: Aks
+    pool: hmcts-cftptl-agent-pool
     displayName: "AKS clusters"
     dependsOn:
       - Managed_Identity
     jobs:
       - job: DeployInfrastructure
-        pool: hmcts-cftptl-agent-pool
         steps:
           - template: pipeline-steps/deploy-service.yaml
             parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,7 +177,6 @@ stages:
       - Managed_Identity
     jobs:
       - job: DeployInfrastructure
-        timeoutInMinutes: 180
         pool:
           vmImage: 'hmcts-cftptl-agent-pool'
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,8 +177,7 @@ stages:
       - Managed_Identity
     jobs:
       - job: DeployInfrastructure
-        pool:
-          vmImage: 'hmcts-cftptl-agent-pool'
+        pool: hmcts-cftptl-agent-pool
         steps:
           - template: pipeline-steps/deploy-service.yaml
             parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,6 +178,8 @@ stages:
     jobs:
       - job: DeployInfrastructure
         timeoutInMinutes: 180
+        pool:
+          vmImage: 'hmcts-cftptl-agent-pool'
         steps:
           - template: pipeline-steps/deploy-service.yaml
             parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,6 +177,7 @@ stages:
       - Managed_Identity
     jobs:
       - job: DeployInfrastructure
+        timeoutInMinutes: 180
         steps:
           - template: pipeline-steps/deploy-service.yaml
             parameters:


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Switch to running AKS stage on self hosted agent pool to overcome maximum job timeouts https://learn.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts 

This should help with AKS GA upgrades which usually take longer than currently allowed 60 minutes imposed by MS Hosted Agentpool

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
