### PR TITLE
Add 180 mintues explicit timeout to DeployInfrastructure job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,6 +178,7 @@ stages:
       - Managed_Identity
     jobs:
       - job: DeployInfrastructure
+        timeoutInMinutes: 180
         steps:
           - template: pipeline-steps/deploy-service.yaml
             parameters:


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Add 180 mintues explicit timeout to DeployInfrastructure job to prevent timeouts

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
