### PR TITLE
DTSPO-11424: Use all_tags instead of common_tags

### DIFF
--- a/components/05-mis/kubelet-identity.tf
+++ b/components/05-mis/kubelet-identity.tf
@@ -3,7 +3,7 @@ resource "azurerm_user_assigned_identity" "kubelet_uami" {
 
   resource_group_name = data.azurerm_resource_group.genesis_rg.name
   location            = data.azurerm_resource_group.genesis_rg.location
-  tags                = local.common_tags
+  tags                = local.all_tags
 }
 
 resource "azurerm_role_assignment" "sbox_registry_acrpull" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-11424](https://tools.hmcts.net/jira/browse/DTSPO-11424)


### Change description ###
Use all_tags instead of common_tags


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
