### PR TITLE
ss-dev-01-aks: Upgrade AKS version from 1.25 to new GA @ 1.26

### DIFF
--- a/environments/aks/dev.tfvars
+++ b/environments/aks/dev.tfvars
@@ -3,7 +3,7 @@ clusters = {
   #     kubernetes_version = "1.25"
   #   },
   "01" = {
-    kubernetes_version = "1.25"
+    kubernetes_version = "1.26"
   },
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12896


### Change description ###

* Upgrade AKS version from 1.25 to new GA version 1.26
* Pluto reports no resources found with known deprecated apiVersions


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
