### PR TITLE
correct private endpoints subnet

### DIFF
--- a/environments/01-network/ptl.tfvars
+++ b/environments/01-network/ptl.tfvars
@@ -14,7 +14,7 @@ additional_subnets = [
   },
   {
     name           = "private-endpoints"
-    address_prefix = "10.147.98.0/22"
+    address_prefix = "10.147.100.0/22"
   }
 ]
 


### PR DESCRIPTION
### Change description ###
Currently failing with 
`subnets/private-endpoints has an invalid CIDR notation. For the given prefix length, the address prefix should be 10.147.96.0/22`

Next available /22 is `10.147.100.0/22` - do we even need this size for private endpoints?

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
