### PR TITLE
DTSPO-15096 Add auto-update issuer URL

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,11 +9,14 @@ resources:
     ref: refs/heads/master
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts'
+  - repository: sds-flux-config
+    type: github
+    ref: refs/heads/master
+    name: hmcts/sds-flux-config
+    endpoint: 'hmcts'
 
 pool:
   vmImage: "ubuntu-latest"
-
-
 
 parameters:
   - name: action
@@ -72,9 +75,7 @@ variables:
     value: ${{ parameters.action }}
   - template: vars/input-variables.yaml@cnp-azuredevops-libraries
 
-
 stages:
-
   - stage: Precheck
     jobs:
       - job:
@@ -123,7 +124,6 @@ stages:
               product: $(product)
               action: ${{ parameters.action }}
 
-
       - job: DeployInfrastructure
         dependsOn: NetworkRg
         steps:
@@ -151,7 +151,6 @@ stages:
               initCommandOptions: >
                 -var subscription_id=$(SUBSCRIPTION_ID)
                 -backend-config storage_account_name=$(STORAGE_ACCOUNT)
-
 
   - stage: Managed_Identity
     displayName: "Managed_Identity"
@@ -193,18 +192,23 @@ stages:
               ${{ if ne(parameters['cluster'], 'All') }}:
                 targetCommand: '-target azurerm_resource_group.kubernetes_resource_group["\"${{parameters.cluster}}\""] -target module.kubernetes["\"${{parameters.cluster}}\""] -target azurerm_role_assignment.dev_to_stg["\"${{parameters.cluster}}\""] -target data.azurerm_resource_group.mi_stg_rg[0]'
 
- 
   - stage: BootStrapClusters
     displayName: "BootStrap Clusters"
     dependsOn: Aks
     jobs:
       - job: BootStrap
+        condition: |
+          or(
+            and(succeeded(), eq('${{ parameters.action }}', 'apply')),
+            and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
+          )
         variables:
           clusters: ${{ parameters.cluster }}
         steps:
           - template: pipeline-steps/bootstrap.yaml
             parameters:
               environment: ${{ parameters.env }}
+              cluster: ${{ parameters.cluster }}
               serviceConnection: $(serviceConnection)
 
   - stage: PipelineTests
@@ -215,7 +219,11 @@ stages:
         pool:
           vmImage: ${{ variables.agentPool }}
         timeoutInMinutes: ${{ variables.timeoutInMinutes }}
-        condition: and(succeeded(), eq(variables['isMain'], true), eq('${{ parameters.action }}', 'apply'))
+        condition: |
+          or(
+            and(succeeded(), eq('${{ parameters.action }}', 'apply')),
+            and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
+          )
         steps:
           - template: steps/pipeline-tests-jest.yaml@cnp-azuredevops-libraries
             parameters:

--- a/pipeline-steps/bootstrap.yaml
+++ b/pipeline-steps/bootstrap.yaml
@@ -7,7 +7,7 @@ parameters:
 
 steps:
 - checkout: self
-- checkout: cnp-flux-config
+- checkout: sds-flux-config
 - template: steps/keyvault-read.yaml@cnp-azuredevops-libraries
   parameters:
     serviceConnection: $(serviceConnection)

--- a/pipeline-steps/bootstrap.yaml
+++ b/pipeline-steps/bootstrap.yaml
@@ -6,7 +6,8 @@ parameters:
   clusterName: ''
 
 steps:
-
+- checkout: self
+- checkout: cnp-flux-config
 - template: steps/keyvault-read.yaml@cnp-azuredevops-libraries
   parameters:
     serviceConnection: $(serviceConnection)
@@ -21,25 +22,38 @@ steps:
       failOnStandardError: 'true'
       inlineScript: |   
         echo "##vso[task.setvariable variable=AZURE_MI_ID]$(az identity show --resource-group genesis-rg --name aks-$(env)-mi --query="clientId" -o tsv)"
+        echo "##vso[task.setvariable variable=AKS_ISSUER_URL]$(az aks show -n ss-${{ parameters.environment }}-${{ parameters.cluster }}-aks -g ss-${{ parameters.environment }}-${{ parameters.cluster }}-rg --query "oidcIssuerProfile.issuerUrl" -otsv)"
 
 - task: Bash@3
   displayName: 'Bootstrap Replacement'
   inputs:
       targetType: 'inline'
-      workingDirectory: '$(System.DefaultWorkingDirectory)/kubernetes/charts/aad-pod-identities'
+      workingDirectory: 'aks-sds-deploy/kubernetes/charts/aad-pod-identities'
       script: |
             sed -i 's|AZURE_SUBSCRIPTION|$(ARM_SUBSCRIPTION_ID)|g' 'aks-sops-role.yaml'
             sed -i 's|AZURE_ENVIRONMENT|$(env)|g' 'aks-sops-role.yaml'
             sed -i 's|MI_CLIENTID|$(AZURE_MI_ID)|g' 'aks-sops-role.yaml'
             cat aks-sops-role.yaml
 
+- task: AzureKeyVault@1
+  displayName: 'Get secrets from Keyvault'
+  inputs:
+    azureSubscription:  "DTS-CFTPTL-INTSVC"
+    keyVaultName:   "cftptl-intsvc"
+    secretsFilter: 'github-management-api-token'
+
+- task: Bash@3
+  displayName: 'Update flux-config'
+  inputs:
+    arguments: ${{ parameters.environment }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) sds-flux-config $(github-management-api-token)
+    filePath: aks-sds-deploy/scripts/update-issuer-url.sh
+
 - task: AzureCLI@1
   displayName: 'Bootstrap'
-  condition: and(succeeded(), eq(variables['action'], 'apply'))
   inputs:
     azureSubscription: $(serviceConnection)
     addSpnToEnvironment: true
     scriptType: shell
     failOnStandardError: 'false'
-    scriptPath: bootstrap/bootstrap.sh
+    scriptPath: aks-sds-deploy/bootstrap/bootstrap.sh
     arguments: $(project) aks $(env) $(controlKeyVault) $(serviceConnection) "$(clusters)" deploy 

--- a/scripts/update-issuer-url.sh
+++ b/scripts/update-issuer-url.sh
@@ -14,7 +14,7 @@ if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
-    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')_test\"/g" $file_path
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\"/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 
@@ -25,7 +25,7 @@ if [ -n "$ISSUER_URL" ]; then
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
         git pull origin master --rebase
-        git push --set-upstream origin HEAD:refs/heads/test_issuer_url
+        git push --set-upstream origin HEAD:master
     else
         echo "No change to issuer URL, skipping git push..."
     fi

--- a/scripts/update-issuer-url.sh
+++ b/scripts/update-issuer-url.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+ENV=$1
+CLUSTER=$2
+ISSUER_URL=$3
+REPO=$4
+GIT_TOKEN=$5
+
+cd "$REPO"
+
+# Update after ISSUER_URL: 
+if [ -n "$ISSUER_URL" ]; then
+    echo "Issuer URL is: ${ISSUER_URL}"
+    #  Make file changes
+    file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')_test\"/g" $file_path
+
+    # Commit changes to github if there is any
+    if [[ -n $(git status -s) ]]; then 
+        git diff .
+        git config --global user.email github-platform-operations@HMCTS.NET
+        git config --global user.name "hmcts-platform-operations"
+        git add .
+        git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
+        git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
+        git pull origin master --rebase
+        git push --set-upstream origin HEAD:refs/heads/test_issuer_url
+    else
+        echo "No change to issuer URL, skipping git push..."
+    fi
+fi


### PR DESCRIPTION
[Similar done in CFT](https://github.com/hmcts/aks-cft-deploy/pull/537)

https://tools.hmcts.net/jira/browse/DTSPO-15096

This change:

  - Adds functionality for automatically updating the OIDC Issuer URL in flux during the aks-sds-deploy pipeline, which is necessary when a cluster is rebuilt, due to workload identity work
  - Bootstrapping clusters is now dependent on this step having run (even if it produces no changes)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
