### PR TITLE
Give admin mi acme access

### DIFF
--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -52,12 +52,16 @@ resource "azurerm_key_vault_access_policy" "sops-policy" {
 }
 
 resource "azurerm_role_assignment" "acme-vault-access" {
-  for_each             = toset([azurerm_user_assigned_identity.sops-mi.principal_id, azurerm_user_assigned_identity.wi-admin-mi.principal_id])
   scope                = data.azurerm_key_vault.acme.id
   role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
 }
 
+resource "azurerm_role_assignment" "admin-acme-vault-access" {
+  scope                = data.azurerm_key_vault.acme.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
+}
 
 locals {
   # Needed for role assignment only

--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -52,6 +52,7 @@ resource "azurerm_key_vault_access_policy" "sops-policy" {
 }
 
 resource "azurerm_role_assignment" "acme-vault-access" {
+  for_each             = toset([azurerm_user_assigned_identity.sops-mi.principal_id, azurerm_user_assigned_identity.wi-admin-mi.principal_id])
   scope                = data.azurerm_key_vault.acme.id
   role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id


### PR DESCRIPTION
Gives the new admin-mi access to acme for traefik migration to workload identity.

Adding it this way instead of for_each, saves recreation of existing role assignment and makes cleaning things up later on easier




<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
