### PR TITLE
Add stg-mi access to dev acme vault

### DIFF
--- a/components/05-mis/03-interpolated-defaults.tf
+++ b/components/05-mis/03-interpolated-defaults.tf
@@ -38,3 +38,9 @@ data "azurerm_key_vault" "acme" {
   name                = "acmedtssds${var.env}"
   resource_group_name = data.azurerm_resource_group.platform-rg.name
 }
+
+
+data "azurerm_key_vault" "acme_dev" {
+  name                = "acmedtssdsdev"
+  resource_group_name = data.azurerm_resource_group.platform-rg.name
+}

--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -63,6 +63,14 @@ resource "azurerm_role_assignment" "admin-acme-vault-access" {
   principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
 }
 
+# Gives stg-mi access to dev acme vault for traefik
+resource "azurerm_role_assignment" "dev-traefik-acme-vault-access" {
+  count                = var.env == "stg" ? 1 : 0
+  scope                = data.azurerm_key_vault.acme_dev.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
+}
+
 locals {
   # Needed for role assignment only
   wi_environment_rg = var.env == "dev" ? "stg" : var.env


### PR DESCRIPTION
Dev is using the admin-stg-mi to create federated credentials against and is using stg-mi in flux -- this leads to traefik not having relevant access. Similar was done for enabling this to work for external-dns



<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
