### PR TITLE
DTSPO-12677 Add stg-mi access to dev acme vault

### DIFF
--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -64,7 +64,7 @@ resource "azurerm_role_assignment" "admin-acme-vault-access" {
 }
 
 # Needed due to ASO restriction and traefik using stg-mi in dev env 
-resource "azurerm_role_assignment" "admin-acme-vault-access" {
+resource "azurerm_role_assignment" "stg-to-dev-acme-vault-access" {
   count                = var.env == "stg" ? 1 : 0
   scope                = local.dev_acme_vault_id
   role_definition_name = "Key Vault Secrets User"

--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -63,9 +63,21 @@ resource "azurerm_role_assignment" "admin-acme-vault-access" {
   principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
 }
 
+# Needed due to ASO restriction and traefik using stg-mi in dev env 
+resource "azurerm_role_assignment" "admin-acme-vault-access" {
+  count                = var.env == "stg" ? 1 : 0
+  scope                = local.dev_acme_vault_id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
+}
+
 locals {
   # Needed for role assignment only
   wi_environment_rg = var.env == "dev" ? "stg" : var.env
+
+  # Dev ACME vault 
+  dev_acme_vault_id = "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/sds-platform-dev-rg/providers/Microsoft.KeyVault/vaults/acmedtssdsdev"
+
   # Needed for for_each loop with these principals before first apply
   mi_prinipal_ids = [
     # sops-mi


### PR DESCRIPTION

[DTSPO-12677](https://tools.hmcts.net/jira/browse/DTSPO-12677)

ASO is configured with STG subscription - so can't override to use dev-mi in admin namespace in dev env. Instead access must be given for the stg mi, which has a federated credential for the dev service account to read from this key vault.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
