### PR TITLE
DTSPO-15841: Updating k8s version to current on DEV

### DIFF
--- a/environments/aks/dev.tfvars
+++ b/environments/aks/dev.tfvars
@@ -3,7 +3,7 @@ clusters = {
   #   kubernetes_version = "1.27"
   # },
   "01" = {
-    kubernetes_version = "1.27"
+    kubernetes_version = "1.28"
   },
 }
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15841

### Change description ###

Updating k8s version to current on DEV from 1.27 to 1.28

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
