### PR TITLE
DTSPO-15841: Update k8s on test00 cluster

### DIFF
--- a/environments/aks/test.tfvars
+++ b/environments/aks/test.tfvars
@@ -1,6 +1,6 @@
 clusters = {
   "00" = {
-    kubernetes_version = "1.27"
+    kubernetes_version = "1.28"
   },
   "01" = {
     kubernetes_version = "1.27"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15841

### Change description ###

Update k8s on test00 cluster from 1.27 to 1.28

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
