### PR TITLE
fix: temporarily route DNAT AKS traffic to VM0

### DIFF
--- a/environments/01-network/demo.tfvars
+++ b/environments/01-network/demo.tfvars
@@ -39,6 +39,24 @@ additional_routes_application_gateway = [
     address_prefix         = "10.10.52.0/24"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "RFC1918_Class_A"
+    address_prefix         = "10.0.0.0/8"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "102PF-A"
+    address_prefix         = "10.232.38.0/23"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.37"
+  },
+  {
+    name                   = "102PF-B"
+    address_prefix         = "10.188.100.0/23"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.37"
   }
 ]
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16913


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
