### PR TITLE
feat: bump max nodes in prod from 10 to 12

### DIFF
--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -15,3 +15,7 @@ oms_agent_enabled                  = true
 monitor_diagnostic_setting         = true
 monitor_diagnostic_setting_metrics = true
 kube_audit_admin_logs_enabled      = true
+
+linux_node_pool = {
+  max_nodes = 12
+}


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Bump the max nodes in the linux pool from 10 (the default) to 12.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
