### PR TITLE
fix: update tier in prod

### DIFF
--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -17,5 +17,7 @@ monitor_diagnostic_setting_metrics = true
 kube_audit_admin_logs_enabled      = true
 
 linux_node_pool = {
-  max_nodes = 12
+  max_nodes = 14
 }
+
+sku_tier = "Standard"


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Update sku tier for AKS clusters in prod, currently set to standard but but pipeline tries to set them back to free.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
