### PR TITLE
Add missing routes to dynatrace

### DIFF
--- a/environments/01-network/demo.tfvars
+++ b/environments/01-network/demo.tfvars
@@ -118,6 +118,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.25.12.0/22"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.37"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/01-network/dev.tfvars
+++ b/environments/01-network/dev.tfvars
@@ -97,5 +97,11 @@ additional_routes_application_gateway = [
     address_prefix         = "10.101.2.128/26"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]

--- a/environments/01-network/ithc.tfvars
+++ b/environments/01-network/ithc.tfvars
@@ -65,11 +65,5 @@ additional_routes = [
     address_prefix         = "10.25.12.0/22"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.37"
-  },
-  {
-    name                   = "dynatrace-nonprod-vnet"
-    address_prefix         = "10.10.80.0/24"
-    next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.36"
   }
 ]

--- a/environments/01-network/ithc.tfvars
+++ b/environments/01-network/ithc.tfvars
@@ -65,5 +65,11 @@ additional_routes = [
     address_prefix         = "10.25.12.0/22"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.37"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]

--- a/environments/01-network/prod.tfvars
+++ b/environments/01-network/prod.tfvars
@@ -110,5 +110,11 @@ additional_routes_application_gateway = [
     address_prefix         = "10.25.16.0/24"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.37"
+  },
+  {
+    name                   = "dynatrace-prod-vnet"
+    address_prefix         = "10.10.81.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
   }
 ]

--- a/environments/01-network/stg.tfvars
+++ b/environments/01-network/stg.tfvars
@@ -77,6 +77,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.25.16.0/24"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.37"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/01-network/test.tfvars
+++ b/environments/01-network/test.tfvars
@@ -85,6 +85,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.25.12.0/22"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.37"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 


### PR DESCRIPTION
### Change description ###
Dynatrace routes were missing on nonprod aks route tables
Connections from dynatrace activegates were reaching applications on the clusters but could not make their way back
This will fix alerts and errors occurring in nonprod dynatrace

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
