### PR TITLE
fix: expand ss test aks route to include the whole vnet

### DIFF
--- a/environments/01-network/ptl.tfvars
+++ b/environments/01-network/ptl.tfvars
@@ -52,8 +52,8 @@ additional_routes = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
-    name                   = "test_aks_iaas_subnet"
-    address_prefix         = "10.141.32.0/25"
+    name                   = "test_aks_vnet"
+    address_prefix         = "10.141.0.0/18"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
   },


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18174

### Change description ###
Expand sds test route to the whole subnet rather than just IaaS

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
