### PR TITLE
update stg peering name for nonprod hub

### DIFF
--- a/components/01-network/21-peering.tf
+++ b/components/01-network/21-peering.tf
@@ -28,7 +28,7 @@ module "vnet_peer_hub_nonprod" {
   for_each = toset([for r in ["ukSouth"] : r if contains(local.hub_to_env_mapping["nonprod"], var.env)])
   peerings = {
     source = {
-      name           = var.env == "ptl" ? "${local.hub["prod"][each.key].peering_name}-nonprod" : local.hub["prod"][each.key].peering_name
+      name           = var.env == "ptl" ? "${local.hub["prod"][each.key].peering_name}-nonprod" : var.env == "stg" ? "${local.hub["prod"][each.key].peering_name}-nonprod" : local.hub["prod"][each.key].peering_name
       vnet           = module.network.network_name
       resource_group = module.network.network_resource_group
     }


### PR DESCRIPTION
### Change description
update stg peering name for nonprod hub

Current error - 
`│ Error: A resource with the ID "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet/virtualNetworkPeerings/hubUkS" already exists `