### PR TITLE
Adding bau-bais to the nle network

### DIFF
--- a/environments/01-network/stg.tfvars
+++ b/environments/01-network/stg.tfvars
@@ -106,6 +106,12 @@ additional_routes = [
     next_hop_in_ip_address = "10.11.8.36"
   },
   {
+    name                   = "bau-bais_private_stg"
+    address_prefix         = "10.225.251.128/28"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
     name                   = "172_16_0_0"
     address_prefix         = "172.16.0.0/12"
     next_hop_type          = "VirtualAppliance"


### PR DESCRIPTION
### Jira link

See https://tools.hmcts.net/jira/browse/DTSPO-18814

### Change description

In order to get the traffic flowing correctly from BAIS to PDDA, we needed to add this route to the aks-stg-rout-table. Since then, we can see the correct traffic on the Palo. [https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/74dacd4f-a248-45bb-a2f0-a[…]s/Microsoft.Network/routeTables/aks-stg-route-table/overview](https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/routeTables/aks-stg-route-table/overview)

### Testing done

Change manually applied and confirmed as working