### PR TITLE
Updated changes to persisits during testing

### DIFF
--- a/environments/01-network/demo.tfvars
+++ b/environments/01-network/demo.tfvars
@@ -36,37 +36,37 @@ additional_routes = [
     name                   = "CGW-Proxy"
     address_prefix         = "10.24.1.253/32"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "102PF-A"
     address_prefix         = "10.232.38.0/23"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "102PF-B"
     address_prefix         = "10.188.100.0/23"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "102PF-C"
     address_prefix         = "10.188.102.0/24"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "Hendon"
     address_prefix         = "10.188.108.0/24"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "Interim-Hosting"
     address_prefix         = "10.25.12.0/22"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 
@@ -93,31 +93,31 @@ additional_routes_application_gateway = [
     name                   = "102PF-A"
     address_prefix         = "10.232.38.0/23"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "102PF-B"
     address_prefix         = "10.188.100.0/23"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "102PF-C"
     address_prefix         = "10.188.102.0/24"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "Hendon"
     address_prefix         = "10.188.108.0/24"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "Interim-Hosting"
     address_prefix         = "10.25.12.0/22"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "dynatrace-nonprod-vnet"


### PR DESCRIPTION
### Change description

Currently working through the DARTS persistence session issues in `demo` environment, made some changes, manually, to the route table entries to point back to the `lb` frontend private ip, subsequent pipeline runs reverted them.

Adding configuration changes to code for the duration of this period and may be reverted back if there is the need too.