### PR TITLE
cleanup as ss-dev does not use NAT addresses now if internal HMCTS Azure

### DIFF
--- a/environments/01-network/dev.tfvars
+++ b/environments/01-network/dev.tfvars
@@ -51,13 +51,13 @@ additional_routes = [
     name                   = "ss-stg-vnet"
     address_prefix         = "10.148.0.0/18"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "pre-vnet01-stg"
     address_prefix         = "10.101.0.0/24"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
 ]
 

--- a/environments/01-network/stg.tfvars
+++ b/environments/01-network/stg.tfvars
@@ -89,12 +89,6 @@ additional_routes_application_gateway = [
     address_prefix         = "10.24.250.0/24"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
-  },
-  {
-    name                   = "ss-dev-vnet-egress-snat"
-    address_prefix         = "10.25.33.0/27"
-    next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
   }
 ]
 
@@ -158,11 +152,5 @@ additional_routes = [
     address_prefix         = "10.145.0.0/18"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
-  },
-  {
-    name                   = "ss-dev-vnet-egress-snat"
-    address_prefix         = "10.25.33.0/27"
-    next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
   }
 ]


### PR DESCRIPTION
### Change description
cleanup as ss-dev does not use NAT addresses now if internal HMCTS Azure