### PR TITLE
cleanup as ss-dev does not use NAT addresses now if internal HMCTS Azure

### DIFF
--- a/environments/01-network/dev.tfvars
+++ b/environments/01-network/dev.tfvars
@@ -51,13 +51,13 @@ additional_routes = [
     name                   = "ss-stg-vnet"
     address_prefix         = "10.148.0.0/18"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
   {
     name                   = "pre-vnet01-stg"
     address_prefix         = "10.101.0.0/24"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
+    next_hop_in_ip_address = "10.11.72.36"
   },
 ]
 


### PR DESCRIPTION
### Change description
cleanup as ss-dev does not use NAT addresses now if internal HMCTS Azure