### PR TITLE
Remove ss-stg-vnet route

### DIFF
--- a/environments/01-network/dev.tfvars
+++ b/environments/01-network/dev.tfvars
@@ -48,12 +48,6 @@ additional_routes = [
     next_hop_in_ip_address = "10.11.72.37"
   },
   {
-    name                   = "ss-stg-vnet"
-    address_prefix         = "10.148.0.0/18"
-    next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.37"
-  },
-  {
     name                   = "pre-vnet01-stg"
     address_prefix         = "10.101.0.0/24"
     next_hop_type          = "VirtualAppliance"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-19071

### Change description
- `ss-dev` -> `ss-stg` found to be very intermittent whilst investigating the above ticket.
- Fix went in on Friday but have been asked to remove route `ss-stg-vnet` as part of this work, so that all `ss-dev` -> `ss-stg` traffic is sent to 10.11.72.36
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
