### PR TITLE
Increase stg nodepool scaling limit

### DIFF
--- a/environments/aks/stg.tfvars
+++ b/environments/aks/stg.tfvars
@@ -15,7 +15,7 @@ availability_zones                     = ["1"]
 autoShutdown = true
 
 linux_node_pool = {
-  max_nodes = 14
+  max_nodes = 16
 }
 
 oms_agent_enabled = true


### PR DESCRIPTION
VH team are having difficulty scaling pods in stg `  0/19 nodes are available:` 

Have been working with them to reduce pod count, requests for mem and cpu etc but still this error shows when trying to add a pod as stg is full but can not scale any more.