### PR TITLE
DTSPO-19113: Increase max pods per node

### DIFF
--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -16,3 +16,7 @@ node_os_maintenance_window_config = {
   start_time = "16:00"
   is_prod    = false
 }
+
+linux_node_pool = {
+  max_pods = 75
+}


### PR DESCRIPTION
This is part of a spike to increase AKS node efficiency, we are currently underutilising our nodes, and other tests we've carried out seem to point to scheduling on nodes having problems due to only allowing 30 pods per node, causing upward autoscaling 

We don't use Azure CNI Overlay, so each node requests an IP in your subnet, and each node then has an IP range it can assign to pods

This POC is to see how AKS behaves when we increase this, see ticket to see PDF of explanation for all envs in CFT/SDS

Hoping to learn:
  - What terraform wants
  - Does default LeastAllocated scheduling strategy still force us onto more nodes even when we increase this?
  - How the current spread of pods handles this change with no manual intervention
  - If this does lead to a reduced node count

Ithc-00:
	subnet: aks-00 (range 10.143.16.0/20) - allows for 4094 IPs (includes loss of required ones for Azure)
	Maximum Number of Nodes: 30 (based on each node pool being scaled to it's current maximum allowed)
	Theoretical Maximum pods per node: 135 (doesn't account for weird BTS azure reservations, so likely a bit below this)


We could try bumping this to 75 to give us plenty of headroom, and observe how scheduling works when removing pods. This is way below the theoretical maximum amount in the worst case scenario, so is safe to try out without exhausting the subnet
