### PR TITLE
Adding a routing rule to enable traffic flow from dev environment to interim hosting

### DIFF
--- a/environments/01-network/dev.tfvars
+++ b/environments/01-network/dev.tfvars
@@ -53,6 +53,12 @@ additional_routes = [
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
   },
+  {
+    name                   = "interim-hosting-12"
+    address_prefix         = "10.25.12.0/22"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.37"
+  },
 ]
 
 additional_routes_application_gateway = [


### PR DESCRIPTION


### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-19164

### Change description

Adding a routing rule to enable traffic flow from dev environment to interim hosting. This was previously covered using using the same route table as prod but with a recent change dev has its own route table but was missing this route.

### Testing done

Tested manually by adding the route via the Azure portal.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
