### PR TITLE
DTSPO-19027-testing-azapi-version-1.15.0

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -65,7 +65,7 @@ data "azuread_service_principal" "aks_auto_shutdown" {
 
 module "kubernetes" {
   for_each    = toset([for k, v in var.clusters : k])
-  source      = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
+  source      = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=DTSPO-19027-testing-deployment-of-automatic-cluster"
   environment = var.env
   location    = var.location
 


### PR DESCRIPTION
### Jira link
[DTSPO-19027](https://tools.hmcts.net/jira/browse/DTSPO-19027)

### Change description

1.15.0 is needed to test automatic cluster,  making this change to test 1.15.0 on our current setup
