### PR TITLE
VIH-11053 increase test aks linux node pool max limit to 16

### DIFF
--- a/environments/aks/test.tfvars
+++ b/environments/aks/test.tfvars
@@ -14,6 +14,10 @@ availability_zones                     = ["1"]
 
 autoShutdown = true
 
+linux_node_pool = {
+  max_nodes = 16
+}
+
 oms_agent_enabled = true
 
 node_os_maintenance_window_config = {


### PR DESCRIPTION
### Jira link

See [VIH-11053](https://tools.hmcts.net/jira/browse/VIH-11053)

### Change description
VH app Helm upgrades are failing because there is not enough CPU capacity across the max 10 nodes on ss-test-00/01-aks clusters to allow the replica set to schedule the new pods. Increasing the max node count to 16 matches that set on staging.

