### PR TITLE
Revert "Switch to azurerm_federated_identity_credential in sbox"

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -65,7 +65,7 @@ data "azuread_service_principal" "aks_auto_shutdown" {
 
 module "kubernetes" {
   for_each    = toset((var.env == "sbox" && var.cluster_automatic) ? [for k, v in var.clusters : k if k == "00"] : [for k, v in var.clusters : k])
-  source      = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=endakelly-patch-1"
+  source      = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
   environment = var.env
   location    = var.location
 


### PR DESCRIPTION
Reverts hmcts/aks-sds-deploy#651

Using the dedicated fed cred resource requires the managed identity be deleted.
A local apply seemed to work with the `removing_special_chars` value