### PR TITLE
Added PTL to mi_vnet_dev route

### DIFF
--- a/environments/01-network/ptl.tfvars
+++ b/environments/01-network/ptl.tfvars
@@ -100,6 +100,12 @@ additional_routes = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
+    name                   = "mi_vnet_dev"
+    address_prefix         = "10.168.1.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
     name                   = "mi_vnet_ithc"
     address_prefix         = "10.168.4.0/24"
     next_hop_type          = "VirtualAppliance"


### PR DESCRIPTION
Need to access mi_vnet_dev resources from SDS Jenkins pipelines.
PTL to the mi_vnet_stg resource seems to work OK so assuming its an issue with the next hop from PTL to dev.