### PR TITLE
Update azure cli to latest

### DIFF
--- a/pipeline-steps/bootstrap.yaml
+++ b/pipeline-steps/bootstrap.yaml
@@ -13,12 +13,13 @@ steps:
     serviceConnection: ${{ parameters.serviceConnection }}
     environment: ${{ parameters.environment }}
 
-- task: AzureCLI@1
+- task: AzureCLI@2
   displayName: 'Setup Authentication'
   inputs:
       azureSubscription: ${{ parameters.serviceConnection }}
       addSpnToEnvironment: true
       scriptLocation: inlineScript
+      scriptType: bash
       failOnStandardError: 'true'
       inlineScript: |   
         echo "##vso[task.setvariable variable=AZURE_MI_ID]$(az identity show --resource-group genesis-rg --name aks-${{ parameters.environment }}-mi --query="clientId" -o tsv)"
@@ -52,12 +53,13 @@ steps:
     filePath: aks-sds-deploy/scripts/update-issuer-url.sh
   condition: ne('${{ parameters.cluster }}', 'All')
 
-- task: AzureCLI@1
+- task: AzureCLI@2
   displayName: 'Bootstrap'
   inputs:
     azureSubscription: ${{ parameters.serviceConnection }}
     addSpnToEnvironment: true
-    scriptType: shell
+    scriptType: bash
+    workingDirectory: aks-sds-deploy/bootstrap
     failOnStandardError: 'false'
     scriptPath: aks-sds-deploy/bootstrap/bootstrap.sh
     arguments: $(project) aks $(env) $(controlKeyVault) ${{ parameters.serviceConnection }} "$(clusters)" deploy 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-21956

Some preview aks apis are coming to deprecation soon, and trying to track down where they come from

Suspicion is here based on activity logs and DTS Bootstrap service principal in use, that an older version of the task here may not be helping

Testing will mostly be done after by re-running the script in here https://gist.github.com/thomast1906/66e1010c30e10f49003a96eb74a12931 and seeing if there is still mention of the same api versions that are due to be deprecated

If this doesn't fix that issue, at least we will be up to date anyway
