### PR TITLE
Revert "DTSPO-22443 - Testing palo failover in demo"

### DIFF
--- a/environments/01-network/demo-pinned-aks-routes.yaml
+++ b/environments/01-network/demo-pinned-aks-routes.yaml
@@ -1,6 +1,6 @@
 # This file contains the additional routes for the application gateway that need to be pinned to a specific Palo.
 # Change this IP to 10.11.72.38 to "failover" to the other Palo.
-next_hop_address: 10.11.72.38
+next_hop_address: 10.11.72.37
 aks_routes:
   - CGW-Proxy:
     address_prefix: 10.24.1.253/32

--- a/environments/01-network/demo-pinned-appgw-routes.yaml
+++ b/environments/01-network/demo-pinned-appgw-routes.yaml
@@ -1,6 +1,6 @@
 # This file contains the additional routes for the application gateway that need to be pinned to a specific Palo.
 # Change this IP to 10.11.72.38 to "failover" to the other Palo.
-next_hop_address: 10.11.72.38
+next_hop_address: 10.11.72.37
 appgw_routes:
   - 102PF-A:
     address_prefix: 10.232.38.0/23


### PR DESCRIPTION
Reverts hmcts/aks-sds-deploy#662

Failing back over to VM-0 following a successful test as part of DTSPO-22443