### PR TITLE
remove shutdown tag

### DIFF
--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -47,5 +47,3 @@ clusters = {
     }
   }
 }
-
-autoShutdown = true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23901

See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

adding a script to auto shutdown VMMS  excluding VMSS which are part of the AKS clusters.  Remove the autoshutdown "true" tag from the clusters to ensure they excluded.


### Testing done



### Checklist
