### PR TITLE
DTSPO-24310: Giving dev and demo MI contributor access to genesis-rg

### DIFF
--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -164,7 +164,7 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
   scope                = "/subscriptions/${local.mi_sds[var.env].subscription_id}"
 }
 
-# Gives dev access to genesis resource group
+# Gives dev access to genesis resource group for WI
 resource "azurerm_role_assignment" "genesis_rg_contributor" {
   count                = var.env == "dev" ? 1 : 0
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id

--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -164,7 +164,7 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
   scope                = "/subscriptions/${local.mi_sds[var.env].subscription_id}"
 }
 
-# Gives dev access to genesis resource group for WI
+# Gives dev and demo access to genesis resource group for WI
 resource "azurerm_role_assignment" "genesis_rg_contributor" {
   count                = var.env == "dev" || var.env == "demo" ? 1 : 0
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id

--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -166,7 +166,7 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
 
 # Gives dev access to genesis resource group for WI
 resource "azurerm_role_assignment" "genesis_rg_contributor" {
-  count                = var.env == "dev" ? 1 : 0
+  count                = var.env == "dev" || var.env == "demo" ? 1 : 0
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_resource_group.genesis_rg.id

--- a/components/05-mis/10-managed-identity.tf
+++ b/components/05-mis/10-managed-identity.tf
@@ -163,3 +163,11 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
   role_definition_name = "Contributor"
   scope                = "/subscriptions/${local.mi_sds[var.env].subscription_id}"
 }
+
+# Gives dev access to genesis resource group
+resource "azurerm_role_assignment" "genesis_rg_contributor" {
+  count                = var.env == "dev" ? 1 : 0
+  principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
+  role_definition_name = "Contributor"
+  scope                = data.azurerm_resource_group.genesis_rg.id
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Giving dev and demo managed identity contributor access to the genesis-rg resource group.
- This is needed as the MI needs write access to the resource group for flux-system workload identity.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
