### PR TITLE
DTSPO-24310: Commenting out higher envs to test new bootstrapping

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,12 +74,12 @@ parameters:
       - env: 'stg'
         dependsOn: 'sbox'
         serviceConnection: 'OPS-APPROVAL-GATE-STG-ENVS'
-      - env: 'ptl'
-        dependsOn: 'ptlsbox'
-        serviceConnection: 'OPS-APPROVAL-GATE-PTL-ENVS'
-      - env: 'prod'
-        dependsOn: 'stg'
-        serviceConnection: 'OPS-APPROVAL-GATE-PROD-ENVS'
+      #- env: 'ptl'
+      #  dependsOn: 'ptlsbox'
+      #  serviceConnection: 'OPS-APPROVAL-GATE-PTL-ENVS'
+      #- env: 'prod'
+       # dependsOn: 'stg'
+       # serviceConnection: 'OPS-APPROVAL-GATE-PROD-ENVS'
 
 variables:
   - name: timeoutInMinutes


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Commenting out prod and PTL to test the new bootstrapping, which has been changed to use workload identity for flux system.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
