### PR TITLE
DTSPO-24310: Uncommenting prod in azure-pipelines to add back to pipeline steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,9 +77,9 @@ parameters:
       - env: 'ptl'
         dependsOn: 'ptlsbox'
         serviceConnection: 'OPS-APPROVAL-GATE-PTL-ENVS'
-      #- env: 'prod'
-       # dependsOn: 'stg'
-       # serviceConnection: 'OPS-APPROVAL-GATE-PROD-ENVS'
+      - env: 'prod'
+        dependsOn: 'stg'
+        serviceConnection: 'OPS-APPROVAL-GATE-PROD-ENVS'
 
 variables:
   - name: timeoutInMinutes


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Uncommenting Prod in azure-pipelines to enable staging through the testing of the new bootstrapping, which has been edited to use workload identity for flux system.
- PTL and prod were commented out in https://github.com/hmcts/aks-sds-deploy/pull/676.
- Bootstrapping has already been applied to the lower environments and PTL successfully.

### Testing done

- The bootstrapping has been applied to and tested successfully on the non-prod environments [here](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=792299&view=results).
- It was added to PTL in [this PR](https://github.com/hmcts/aks-sds-deploy/pull/677) and applied in [this run](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=793351&view=results).

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
