### PR TITLE
Clean up github app secret files between runs

### DIFF
--- a/bootstrap/create-github-app-secret.sh
+++ b/bootstrap/create-github-app-secret.sh
@@ -13,6 +13,10 @@ if [[ -z $flux_github_app_id ]] || [[ -z $flux_github_app_installation_id ]] || 
             exit 1
     else
             echo "Downloading Flux GitHub App secrets from Key Vault"
+            # Remove any existing secrets to avoid conflicts if the same Agent happens to execute on multiple envs
+            rm -f $AGENT_BUILDDIRECTORY/flux-github-app-id
+            rm -f $AGENT_BUILDDIRECTORY/flux-github-app-installation-id
+            rm -f $AGENT_BUILDDIRECTORY/flux-github-app-private-key
             az keyvault secret download --name flux-github-app-id --vault-name ${az_keyvault_name} --file $AGENT_BUILDDIRECTORY/flux-github-app-id --encoding ascii
             az keyvault secret download --name flux-github-app-installation-id --vault-name ${az_keyvault_name} --file $AGENT_BUILDDIRECTORY/flux-github-app-installation-id --encoding ascii
             az keyvault secret download --name flux-github-app-priv-key --vault-name ${az_keyvault_name} --file $AGENT_BUILDDIRECTORY/flux-github-app-private-key --encoding ascii

--- a/bootstrap/deploy-flux.sh
+++ b/bootstrap/deploy-flux.sh
@@ -121,6 +121,10 @@ function flux_github_app_secret {
     --from-file=githubAppPrivateKey=$AGENT_BUILDDIRECTORY/flux-github-app-private-key \
     --namespace flux-system \
     --dry-run=client -o yaml > "${TMP_DIR}/gotk/github-app-credentials.yaml"
+    # Clean up these secret files - they are not needed anymore and to avoid conflicts on subsequent runs on the same agent
+    rm -f $AGENT_BUILDDIRECTORY/flux-github-app-id
+    rm -f $AGENT_BUILDDIRECTORY/flux-github-app-installation-id
+    rm -f $AGENT_BUILDDIRECTORY/flux-github-app-private-key
 }
 
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24241

### Change description
Looks like ADO agents persist files in /tmp folder between stages so remove github app secret files between runs to avoid conflicts

### Testing done
I am seeing errors in some bootstrap stages where `az keyvault secret download` complains file already exists while other in other environments this works fine.
Given these secret files are being created for the first time, it would be impossible for them to already exist for each environment so these must be secret files remaining from the last stage run when the same Agent happens to be running two bootstrap stages.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
