### PR TITLE
DTSPO-27913: Remove Windows node pool to enable K8s 1.33 upgrade

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -87,7 +87,7 @@ module "kubernetes" {
 
   node_os_maintenance_window_config = each.value.node_os_maintenance_window_config
 
-  additional_node_pools = contains(["ptlsbox", "ptl"], var.env) ? tolist([
+  additional_node_pools = contains(["ptlsbox", "ptl", "sbox"], var.env) ? tolist([
     {
       name                = "linux"
       vm_size             = lookup(each.value.linux_node_pool, "vm_size", "Standard_D4ds_v5")
@@ -122,19 +122,17 @@ module "kubernetes" {
       enable_auto_scaling = true
       mode                = "User"
     },
-    # Removed Windows node pool to allow upgrade to Kubernetes 1.33
-    # Windows Server 2019 is deprecated in Kubernetes 1.33+
-    # {
-    #   name                = "msnode"
-    #   vm_size             = lookup(var.windows_node_pool, "vm_size", "Standard_D4ds_v5")
-    #   min_count           = lookup(var.windows_node_pool, "min_nodes", 2)
-    #   max_count           = lookup(var.windows_node_pool, "max_nodes", 4)
-    #   max_pods            = lookup(var.windows_node_pool, "max_pods", 30)
-    #   os_type             = "Windows"
-    #   node_taints         = ["kubernetes.io/os=windows:NoSchedule"]
-    #   enable_auto_scaling = true
-    #   mode                = "User"
-    # },
+    {
+      name                = "msnode"
+      vm_size             = lookup(var.windows_node_pool, "vm_size", "Standard_D4ds_v5")
+      min_count           = lookup(var.windows_node_pool, "min_nodes", 2)
+      max_count           = lookup(var.windows_node_pool, "max_nodes", 4)
+      max_pods            = lookup(var.windows_node_pool, "max_pods", 30)
+      os_type             = "Windows"
+      node_taints         = ["kubernetes.io/os=windows:NoSchedule"]
+      enable_auto_scaling = true
+      mode                = "User"
+    },
     {
       name                = "cronjob"
       vm_size             = "Standard_D4ds_v5"

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -52,7 +52,7 @@ clusters = {
 autoShutdown      = true
 cluster_automatic = false
 
-windows_node_pool = {
-  min_nodes = 2
-  max_nodes = 4
-}
+# windows_node_pool = {
+#   min_nodes = 2
+#   max_nodes = 4
+# }


### PR DESCRIPTION

### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27913


### Change description
- Commented out msnode Windows node pool (Windows Server 2019)
- Windows Server 2019 is deprecated in Kubernetes 1.33+
- No workloads currently running on Windows nodes
- This allows both ss-sbox-00-aks and ss-sbox-01-aks to upgrade to K8s 1.33


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
