### PR TITLE
Add subscription id map to genesis component and pass the jenkins mi …

### DIFF
--- a/components/00-genesis/00-init.tf
+++ b/components/00-genesis/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.117.1"
+      version = "4.0.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/components/00-genesis/10-genesis.tf
+++ b/components/00-genesis/10-genesis.tf
@@ -40,7 +40,7 @@ locals {
 }
 
 module "genesis" {
-  source                  = "git::https://github.com/hmcts/aks-module-genesis.git?ref=dtspo-30482-grant-per-env-jenkins-mi-on-kv"
+  source                  = "git::https://github.com/hmcts/aks-module-genesis.git?ref=master"
   environment             = var.env
   tags                    = module.ctags.common_tags
   developers_group        = local.developers_group

--- a/components/00-genesis/10-genesis.tf
+++ b/components/00-genesis/10-genesis.tf
@@ -39,7 +39,7 @@ locals {
 }
 
 module "genesis" {
-  source                  = "git::https://github.com/hmcts/aks-module-genesis.git?ref=master"
+  source                  = "git::https://github.com/hmcts/aks-module-genesis.git?ref=dtspo-30482-grant-per-env-jenkins-mi-on-kv"
   environment             = var.env
   tags                    = module.ctags.common_tags
   developers_group        = local.developers_group

--- a/components/00-genesis/10-genesis.tf
+++ b/components/00-genesis/10-genesis.tf
@@ -1,9 +1,52 @@
+locals {
+    mi_sds = {
+    # DTS-SHAREDSERVICES-SBOX
+    sbox = {
+      subscription_id = "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
+    }
+    # DTS-SHAREDSERVICES-STG
+    dev = {
+      subscription_id = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
+    }
+    stg = {
+      subscription_id = "74dacd4f-a248-45bb-a2f0-af700dc4cf689"
+    }
+    # DTS-SHAREDSERVICES-ITHC
+    ithc = {
+      subscription_id = "ba71a911-e0d6-4776-a1a6-079af1df7139"
+    }
+    # DTS-SHAREDSERVICES-TEST
+    test = {
+      subscription_id = "3eec5bde-7feb-4566-bfb6-805df6e10b90"
+    }
+    # DTS-SHAREDSERVICES-DEMO
+    demo = {
+      subscription_id = "c68a4bed-4c3d-4956-af51-4ae164c1957c"
+    }
+    # DTS-SHAREDSERVICES-PROD
+    prod = {
+      subscription_id = "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
+    }
+    # DTS-SHAREDSERVICESPTL-SBOX
+    ptlsbox = {
+      subscription_id = "64b1c6d6-1481-44ad-b620-d8fe26a2c768"
+    }
+    # DTS-SHAREDSERVICESPTL
+    ptl = {
+      subscription_id = "6c4d2513-a873-41b4-afdd-b05a33206631"
+    }
+  }
+}
+
 module "genesis" {
-  source           = "git::https://github.com/hmcts/aks-module-genesis.git?ref=master"
-  environment      = var.env
-  tags             = module.ctags.common_tags
-  developers_group = local.developers_group
-  business_area    = lower(module.ctags.common_tags["businessArea"])
+  source                  = "git::https://github.com/hmcts/aks-module-genesis.git?ref=master"
+  environment             = var.env
+  tags                    = module.ctags.common_tags
+  developers_group        = local.developers_group
+  business_area           = lower(module.ctags.common_tags["businessArea"])
+  jenkins_provider_sub_id = local.mi_cft[var.env].subscription_id
+  jenkins_mi_name         = "jenkins-${var.env}-mi"
+  jenkins_mi_rg_name      = "managed-identities-${var.env}-rg"
 }
 
 module "ctags" {

--- a/components/00-genesis/10-genesis.tf
+++ b/components/00-genesis/10-genesis.tf
@@ -44,7 +44,7 @@ module "genesis" {
   tags                    = module.ctags.common_tags
   developers_group        = local.developers_group
   business_area           = lower(module.ctags.common_tags["businessArea"])
-  jenkins_provider_sub_id = local.mi_cft[var.env].subscription_id
+  jenkins_provider_sub_id = local.mi_sds[var.env].subscription_id
   jenkins_mi_name         = "jenkins-${var.env}-mi"
   jenkins_mi_rg_name      = "managed-identities-${var.env}-rg"
 }

--- a/components/00-genesis/10-genesis.tf
+++ b/components/00-genesis/10-genesis.tf
@@ -4,10 +4,11 @@ locals {
     sbox = {
       subscription_id = "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
     }
-    # DTS-SHAREDSERVICES-STG
+    # DTS-SHAREDSERVICES-DEV
     dev = {
-      subscription_id = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
+      subscription_id = "867a878b-cb68-4de5-9741-361ac9e178b6"
     }
+    # DTS-SHAREDSERVICES-STG
     stg = {
       subscription_id = "74dacd4f-a248-45bb-a2f0-af700dc4cf689"
     }

--- a/components/00-genesis/10-genesis.tf
+++ b/components/00-genesis/10-genesis.tf
@@ -10,7 +10,7 @@ locals {
     }
     # DTS-SHAREDSERVICES-STG
     stg = {
-      subscription_id = "74dacd4f-a248-45bb-a2f0-af700dc4cf689"
+      subscription_id = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
     }
     # DTS-SHAREDSERVICES-ITHC
     ithc = {

--- a/components/01-network/00-init.tf
+++ b/components/01-network/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.117.1"
+      version = "4.0.0"
     }
   }
 }

--- a/components/01-network/20-network.tf
+++ b/components/01-network/20-network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source = "git::https://github.com/hmcts/aks-module-network.git?ref=4.x"
+  source = "git::https://github.com/hmcts/aks-module-network.git?ref=feat/azurerm-4.x"
 
   resource_group_name = local.network_resource_group_name
 

--- a/components/01-network/20-network.tf
+++ b/components/01-network/20-network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source = "git::https://github.com/hmcts/aks-module-network.git?ref=master"
+  source = "git::https://github.com/hmcts/aks-module-network.git?ref=4.x"
 
   resource_group_name = local.network_resource_group_name
 

--- a/components/05-mis/00-init.tf
+++ b/components/05-mis/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.117.1"
+      version = "4.0.0"
     }
   }
 }

--- a/components/07-network-rg/00-init.tf
+++ b/components/07-network-rg/00-init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.117.1"
+      version = "4.0.0"
     }
   }
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-30482

### Change description

- Upgrade azurerm provider to 4.0.0 to fix nagger failure
- Update network module to 4.x supported branch 
- Add sub id map for jenkins env mis
- Pass jenkins mi name, rg and sub id to the genesis module to ensure access policy for relevant jenkins mi/env is created

### Testing done

Plan looks ok (there is just version change listed 1.34.4 - 1.34 in non-prod clusters so likely patch version upgrade)

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/aks-sds-deploy/780